### PR TITLE
workflows(parser): Clean up APS affiliation organization text

### DIFF
--- a/dags/aps/parser.py
+++ b/dags/aps/parser.py
@@ -119,11 +119,9 @@ class APSParser(IParser):
 
                 parsed_affiliations.append(
                     {
-                        "value": affiliation[
-                            "name"
-                        ],  
-                        "organization": org_name,  
-                        "ror": ror,  
+                        "value": affiliation["name"],
+                        "organization": org_name,
+                        "ror": ror,
                     }
                 )
         return parsed_affiliations

--- a/dags/aps/parser.py
+++ b/dags/aps/parser.py
@@ -98,7 +98,7 @@ class APSParser(IParser):
         ]
 
     def extract_organization_and_ror(self, text):
-        pattern = r'<a href="([^"]+)">(.*?)</a>'
+        pattern = r'<a href="([^"]+)">(.*?)</a>.*'
 
         ror_url = None
 
@@ -112,17 +112,20 @@ class APSParser(IParser):
         return modified_text, ror_url
 
     def _get_affiliations(self, article, affiliationIds):
-        parsed_affiliations = [
-            {
-                "value": affiliation["name"],
-                "organization": self.extract_organization_and_ror(affiliation["name"])[
-                    0
-                ],
-                "ror": self.extract_organization_and_ror(affiliation["name"])[1],
-            }
-            for affiliation in article["affiliations"]
-            if affiliation.get("id") in affiliationIds
-        ]
+        parsed_affiliations = []
+        for affiliation in article["affiliations"]:
+            if affiliation.get("id") in affiliationIds:
+                org_name, ror = self.extract_organization_and_ror(affiliation["name"])
+
+                parsed_affiliations.append(
+                    {
+                        "value": affiliation[
+                            "name"
+                        ],  
+                        "organization": org_name,  
+                        "ror": ror,  
+                    }
+                )
         return parsed_affiliations
 
     def _get_field_categories(self, article):

--- a/tests/units/aps/test_aps_parser.py
+++ b/tests/units/aps/test_aps_parser.py
@@ -62,7 +62,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",  
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -74,7 +74,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -86,7 +86,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -98,7 +98,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -112,7 +112,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -124,7 +124,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -136,7 +136,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],

--- a/tests/units/aps/test_aps_parser.py
+++ b/tests/units/aps/test_aps_parser.py
@@ -62,7 +62,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",  
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -74,7 +74,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -86,7 +86,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -98,7 +98,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -112,7 +112,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -124,7 +124,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],
@@ -136,7 +136,7 @@ def parsed_articles(parser, articles):
                         "affiliations": [
                             {
                                 "value": 'Department of Physics and Astronomy, <a href="https://ror.org/02vm5rt34">Vanderbilt University</a>, Nashville, Tennessee 37240, USA',
-                                "organization": "Department of Physics and Astronomy, Vanderbilt University",   
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University",
                                 "ror": "https://ror.org/02vm5rt34",
                             }
                         ],


### PR DESCRIPTION
* Remove address and country data from the organization field

* ref: #524